### PR TITLE
Fix compatibility with ClickHouse 23.4

### DIFF
--- a/music2.sql.sh
+++ b/music2.sql.sh
@@ -68,4 +68,5 @@ mono(output(
         * sine_wave(time * 80 * exp2(x / 3)),
         range(12))))
 
-FROM system.numbers;
+FROM system.numbers
+SETTINGS max_threads = 1;

--- a/play.sh
+++ b/play.sh
@@ -26,11 +26,11 @@ then
     exec 3<>$PIPE
     rm $PIPE
 
-    clickhouse-local --format RowBinary --query "SELECT number FROM system.numbers" >&3 &
+    clickhouse-local --format RowBinary --max_threads 1 --query "SELECT number FROM system.numbers" >&3 &
 
     while true
     do
-        clickhouse-local --allow_experimental_analyzer 1 --format RowBinary --structure "number UInt64" --query "$(cat $MUSIC)" <&3 | aplay -f cd &
+        clickhouse-local --allow_experimental_analyzer 1 --format RowBinary --max_threads 1 --structure "number UInt64" --query "$(cat $MUSIC)" <&3 | aplay -f cd &
         PID=$!
         inotifywait -e modify $MUSIC
         echo "Music changed." >&2
@@ -40,7 +40,7 @@ then
 else
     # Fallback to a simple option:
 
-    clickhouse-local --format RowBinary --query "SELECT number FROM system.numbers" | \
-        clickhouse-local --allow_experimental_analyzer 1 --format RowBinary --structure "number UInt64" --query "$(cat $MUSIC)" | \
+    clickhouse-local --format RowBinary --max_threads 1 --query "SELECT number FROM system.numbers" | \
+        clickhouse-local --allow_experimental_analyzer 1 --format RowBinary --max_threads 1 --structure "number UInt64" --query "$(cat $MUSIC)" | \
         play -t raw -b 16 -e signed -c 2 -v .75 -r 44100 -
 fi


### PR DESCRIPTION
This PR https://github.com/ClickHouse/ClickHouse/pull/48525 breaks sound by reordering the blocks.